### PR TITLE
Fixing formatting for code blocks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,10 +7,11 @@ Note: bcp currently assumes a trusted network, use with caution
 
 Compiling
 ---------
+::
 
-make
-or
-gcc -D_FILE_OFFSET_BITS=64 -o bcp bcp.c
+  make
+  or
+  gcc -D_FILE_OFFSET_BITS=64 -o bcp bcp.c
 
 
 Usage
@@ -23,18 +24,19 @@ To receive the file: ./bcp
 
 Example
 -------
+::
 
-diginux@heisenberg:~/code/bcp/test$ ./bcp awesome.jpg
-Listening for request..
-Sending file to: 192.168.2.12:10789
-Sent 107545
-File sent.
+  diginux@heisenberg:~/code/bcp/test$ ./bcp awesome.jpg
+  Listening for request..
+  Sending file to: 192.168.2.12:10789
+  Sent 107545
+  File sent.
 
-Jordans-MacBook-Pro:bcp diginux$ ./bcp
-Requesting file..
-Incoming connection from: 192.168.2.12
-Receive: 107545
-File received: awesome.jpg
+  Jordans-MacBook-Pro:bcp diginux$ ./bcp
+  Requesting file..
+  Incoming connection from: 192.168.2.12
+  Receive: 107545
+  File received: awesome.jpg
 
 
 Alternatives:


### PR DESCRIPTION
Just a quick little fix so that the readme looks a bit more clear.
